### PR TITLE
DefaultFunctions needs to be public for bindings to work

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.12-R0.1-SNAPSHOT</version>
+            <version>1.13.2-R0.1-SNAPSHOT</version>
             <type>jar</type>
             <scope>provided</scope>
         </dependency>

--- a/src/main/java/buscript/BuscriptPlugin.java
+++ b/src/main/java/buscript/BuscriptPlugin.java
@@ -54,7 +54,10 @@ public class BuscriptPlugin extends JavaPlugin {
                 player = (Player) sender;
             }
             if (args.length == 1) {
-                getAPI().executeScript(scriptFile, new BukkitScriptExecutor(player));
+                if(player != null)
+                    getAPI().executeScript(scriptFile, player.getPlayerListName(), new BukkitScriptExecutor(player));
+                else
+                    getAPI().executeScript(scriptFile, new BukkitScriptExecutor(player));
                 return true;
             } else if (args.length == 2) {
                 getAPI().executeScript(scriptFile, args[1], new BukkitScriptExecutor(player));

--- a/src/main/java/buscript/DefaultFunctions.java
+++ b/src/main/java/buscript/DefaultFunctions.java
@@ -8,7 +8,7 @@ import org.bukkit.entity.Player;
 
 import java.io.File;
 
-class DefaultFunctions {
+public class DefaultFunctions {
 
     private Buscript buscript;
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ main: buscript.BuscriptPlugin
 version: maven-version-number
 author: dumptruckman
 softdepend: [Vault]
+api-version: 1.13
 
 commands:
   run:


### PR DESCRIPTION
With my JVM (Oracle jdk1.8.0_251) The global functions defined in DefaultFunctions result in errors like

 ReferenceError: "broadcast" is not defined in &lt;eval&gt;

unless DefaultFunctions is declared public. 